### PR TITLE
init: Discourage -prune usage by adding warning

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -971,6 +971,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     if (args.GetIntArg("-prune", 0)) {
+        LogWarning("Running with -prune means this node is unable to serve old blocks to peers who are doing "
+                   "initial block download. Disable -prune to increase the strength of the network.");
         if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX))
             return InitError(_("Prune mode is incompatible with -txindex."));
         if (args.GetBoolArg("-reindex-chainstate", false)) {


### PR DESCRIPTION
What do you think? Hopefully doing this won't damage my reputation. :)

doc/developer-notes.md states:
> `LogWarning(fmt, params...)` should be used in place of `LogInfo` for
>  severe problems that the node admin should address, but are not
>  severe enough to warrant shutting down the node (e.g., system time
>  appears to be wrong, unknown soft fork appears to have activated)."

I think giving it this strength would be good, but could concede to `LogInfo("WARNING: ...")` like some other cases in the file. There's also `InitWarning()`, but that seems to display a popup every time one starts bitcoin-qt (haven't verified), also it writes the warning twice to the console output (maybe only once to debug.log).

An option might be to do `LogWarning("%s", _("<message>"))` in order to encourage translations of the message.

Console output:
```
₿ ./build/bin/bitcoind -regtest -prune=1
2025-05-09T13:38:14Z Bitcoin Core version v29.99.0-c3c101058e2d-dirty (release build)
2025-05-09T13:38:14Z [warning] Option '-upnp=true' is given but UPnP support was dropped in version 29.0.
2025-05-09T13:53:29Z [warning] Running with -prune means this node is unable to serve old blocks to peers who are doing initial block download. Disable -prune to increase the strength of the network.
2025-05-09T13:38:14Z Using the 'sse4(1way),sse41(4way),avx2(8way)' SHA256 implementation
2025-05-09T13:38:14Z Using RdSeed as an additional entropy source
```

### Motivation

While enabling people to run pruned nodes is better than them not running nodes at all, we should encourage full nodes to maximize network health/decentralization.

Edit: Warning could also mention how txindex doesn't work when pruning since it references block file data, and lightning nodes are shaky (https://github.com/bitcoin/bitcoin/pull/32406#issuecomment-2972084637, https://docs.corelightning.org/docs/bitcoin-core#using-a-pruned-bitcoin-core-node, LND falling back to 4-8 L1 peers which better not all be pruned, in case there is a 48h attack on LND which makes it unable to keep track of the chain - however, CLTV values for HTLCs are just a few hours, so 48h may be an eternity).